### PR TITLE
Support compiler chaining (weave compiled classes)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,6 +90,17 @@ The module trait `de.tobiasroeser.mill.aspectj.AspectjModule` has the following 
 `def ajcHelp: Command[Unit]`::
   Shows the help of the AspectJ compiler (`ajc -help`).
 
+== Mixing in the Aspectj-Compiler in an existing Compiler chains (aka Scala support)
+
+If you override the `def aspectjCompileMode` to return `CompileMode.OnlyAjSources`, you can chain the AspectJ compilr after another compiler.
+
+In this setup, the AspectJ compiler only weave-compiles
+already compiled classes.
+Only `*.aj` files are fed as source files, all other
+inputs (the already compiled classes) are fed via the `-inpath` option.
+
+With this setup, we can even compile-time weave Scala (and probably also Kotlin) classes. But this only works reliably with Mill 0.10.0 and newer.
+
 == Version Compatibility Matrix
 
 Mill is still in active development, and has no stable API yet.
@@ -172,6 +183,8 @@ You can also ask question and join our discussion at the {projectHome}/discussio
 :version: main
 :prev-version: 0.3.2
 :github-milestone: 4
+
+* New `aspectjCompileMode` config option, to use Aspectj compiler to weave-compile already compiled classes.
 
 
 _See

--- a/api/src/de/tobiasroeser/mill/aspectj/worker/AspectjWorker.scala
+++ b/api/src/de/tobiasroeser/mill/aspectj/worker/AspectjWorker.scala
@@ -9,7 +9,7 @@ trait AspectjWorker {
   /**
    * Invokes the Aspectj compiler
    * @param classpath
-   * @param sourceDirs
+   * @param sourceFiles
    * @param options
    * @param aspectPath
    * @param inPath
@@ -19,7 +19,7 @@ trait AspectjWorker {
    */
   def compile(
     classpath: Seq[Path],
-    sourceDirs: Seq[Path],
+    sourceFiles: Seq[Path],
     options: Seq[String],
     aspectPath: Seq[Path],
     inPath: Seq[Path],

--- a/aspectj/src/de/tobiasroeser/mill/aspectj/CompileMode.scala
+++ b/aspectj/src/de/tobiasroeser/mill/aspectj/CompileMode.scala
@@ -1,0 +1,20 @@
+package de.tobiasroeser.mill.aspectj
+
+/**
+ * Decide want kind of sources the compiler is processing.
+ */
+sealed trait CompileMode
+
+object CompileMode {
+
+  /**
+   * Process all source files (`*.java`  and `*.aj`)
+   */
+  final case object FullSources extends CompileMode
+
+  /**
+   * Only process `*.aj` files but weave-compile all other classes given via `-inpath`.
+   * This setup requires another compiler to compile the Java (and other) source files to class files.
+   */
+  final case object OnlyAjSources extends CompileMode
+}

--- a/itest/src/javac+ajc/build.sc
+++ b/itest/src/javac+ajc/build.sc
@@ -1,0 +1,41 @@
+import mill._
+import mill.scalalib._
+import mill.define._
+
+import $exec.plugins
+import de.tobiasroeser.mill.aspectj._
+
+import $ivy.`org.scalatest::scalatest:3.2.10`
+import org.scalatest.Assertions
+
+object main extends AspectjModule {
+
+  def aspectjVersion = "1.9.5"
+  def aspectjCompileMode = CompileMode.OnlyAjSources
+
+  override def javacOptions = Seq("-source", "1.8", "-target", "1.8")
+  def ajcOptions = Seq("-1.8")
+
+  object test extends Tests {
+    def javacOptions = Seq("-source", "1.8", "-target", "1.8")
+    def testFrameworks = Seq("com.novocode.junit.JUnitFramework")
+    def ivyDeps = Agg(
+      ivy"com.novocode:junit-interface:0.11",
+      ivy"de.tototec:de.tobiasroeser.lambdatest:0.7.0"
+    )
+  }
+
+}
+
+def verify(): Command[Unit] = T.command {
+
+  val A = new Assertions{}
+  import A._
+
+  val cr = main.compile()
+  main.test.test()()
+
+  assert(main.ajcSourceFiles().map(_.path) == Seq(main.millSourcePath / "src" / "BeforeAspect.aj"))
+
+  ()
+}

--- a/itest/src/javac+ajc/main/src/BeforeAspect.aj
+++ b/itest/src/javac+ajc/main/src/BeforeAspect.aj
@@ -1,0 +1,11 @@
+/**
+ * A (old) AspectJ stype aspect.
+ */
+public aspect BeforeAspect
+{
+    pointcut printPointcut():execution(* ClassToWeave.print(..));
+
+    before() : printPointcut(){
+        System.out.println( "before print()" );
+    }
+}

--- a/itest/src/javac+ajc/main/src/ClassToWeave.java
+++ b/itest/src/javac+ajc/main/src/ClassToWeave.java
@@ -1,0 +1,10 @@
+/**
+ * The Class to get woven
+ */
+public class ClassToWeave
+{
+    public void print()
+    {
+        System.out.println( "Weave me" );
+    }
+}

--- a/itest/src/javac+ajc/main/src/TraceAspect.java
+++ b/itest/src/javac+ajc/main/src/TraceAspect.java
@@ -1,0 +1,15 @@
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+/**
+ * A @AspectJ style aspect.
+ */
+@Aspect
+public class TraceAspect
+{
+    @Before ("execution (* ClassToWeave.print(..))")
+    public void trace()
+    { 
+        System.out.println("Trace");
+    }
+}

--- a/itest/src/javac+ajc/main/test/src/Test.java
+++ b/itest/src/javac+ajc/main/test/src/Test.java
@@ -1,0 +1,34 @@
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import de.tobiasroeser.lambdatest.junit.FreeSpec;
+
+import static de.tobiasroeser.lambdatest.Expect.*;
+
+public class Test extends FreeSpec {
+
+	public Test() {
+
+		test("ClassToWeave.print should also print aspects", () -> {
+			final PrintStream origOut = System.out;
+			final ByteArrayOutputStream cacheOut = new ByteArrayOutputStream();
+			final PrintStream testOut = new PrintStream(cacheOut);
+			System.setOut(testOut);
+			try {
+				new ClassToWeave().print();
+				expectString(cacheOut.toString())
+						.contains("Weave me")
+						.contains("Trace")
+						.contains("before print()");
+
+			} finally {
+				expectEquals(System.out, testOut, "System.out is no longer the same");
+				System.setOut(origOut);
+				origOut.print(cacheOut.toString());
+			}
+		});
+
+
+	}
+
+}

--- a/itest/src/scala+ajc/build.sc
+++ b/itest/src/scala+ajc/build.sc
@@ -1,0 +1,43 @@
+import mill._
+import mill.scalalib._
+import mill.define._
+
+import $exec.plugins
+import de.tobiasroeser.mill.aspectj._
+
+import $ivy.`org.scalatest::scalatest:3.2.10`
+import org.scalatest.Assertions
+
+object main extends ScalaModule with AspectjModule {
+
+  def scalaVersion = "2.13.8"
+  def aspectjVersion = "1.9.5"
+  def aspectjCompileMode = CompileMode.OnlyAjSources
+
+  override def scalacOptions = Seq("-target:jvm-1.8")
+  override def ajcOptions = Seq("-1.8")
+
+  object test extends Tests {
+    override def javacOptions = Seq("-source", "1.8", "-target", "1.8")
+    override def scalacOptions = Seq("-target:jvm-1.8")
+    def testFrameworks = Seq("com.novocode.junit.JUnitFramework")
+    override def ivyDeps = Agg(
+      ivy"com.novocode:junit-interface:0.11",
+      ivy"de.tototec:de.tobiasroeser.lambdatest:0.7.0"
+    )
+  }
+
+}
+
+def verify(): Command[Unit] = T.command {
+
+  val A = new Assertions{}
+  import A._
+
+  val cr = main.compile()
+  main.test.test()()
+
+  assert(main.ajcSourceFiles().map(_.path) == Seq(main.millSourcePath / "src" / "BeforeAspect.aj"))
+
+  ()
+}

--- a/itest/src/scala+ajc/main/src/BeforeAspect.aj
+++ b/itest/src/scala+ajc/main/src/BeforeAspect.aj
@@ -1,0 +1,11 @@
+/**
+ * A (old) AspectJ stype aspect.
+ */
+public aspect BeforeAspect
+{
+    pointcut printPointcut():execution(* ClassToWeave.print(..));
+
+    before() : printPointcut(){
+        System.out.println( "before print()" );
+    }
+}

--- a/itest/src/scala+ajc/main/src/ClassToWeave.scala
+++ b/itest/src/scala+ajc/main/src/ClassToWeave.scala
@@ -1,0 +1,8 @@
+/**
+ * The Class to get woven
+ */
+class ClassToWeave() {
+  def print(): Unit = {
+    println("Weave me")
+  }
+}

--- a/itest/src/scala+ajc/main/src/TraceAspect.java
+++ b/itest/src/scala+ajc/main/src/TraceAspect.java
@@ -1,0 +1,15 @@
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+/**
+ * A @AspectJ style aspect.
+ */
+@Aspect
+public class TraceAspect
+{
+    @Before ("execution (* ClassToWeave.print(..))")
+    public void trace()
+    { 
+        System.out.println("Trace");
+    }
+}

--- a/itest/src/scala+ajc/main/test/src/Test.java
+++ b/itest/src/scala+ajc/main/test/src/Test.java
@@ -1,0 +1,34 @@
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import de.tobiasroeser.lambdatest.junit.FreeSpec;
+
+import static de.tobiasroeser.lambdatest.Expect.*;
+
+public class Test extends FreeSpec {
+
+	public Test() {
+
+		test("ClassToWeave.print should also print aspects", () -> {
+			final PrintStream origOut = System.out;
+			final ByteArrayOutputStream cacheOut = new ByteArrayOutputStream();
+			final PrintStream testOut = new PrintStream(cacheOut);
+			System.setOut(testOut);
+			try {
+				new ClassToWeave().print();
+				expectString(cacheOut.toString())
+						.contains("Weave me")
+						.contains("Trace")
+						.contains("before print()");
+
+			} finally {
+				expectEquals(System.out, testOut, "System.out is no longer the same");
+				System.setOut(origOut);
+				origOut.print(cacheOut.toString());
+			}
+		});
+
+
+	}
+
+}


### PR DESCRIPTION
Added `aspectjCompileMode` to weave-compile after another compiler.

`CompileMode.FullSources` is the default and only used AspectJ compiler
for all compilations.

`CompileMode.OnlyAjSources` is the new setup to use another compiler to
compile the Java sources, and use AspectJ compiler only to weave-compile
those compiled classes. Only aj-files are fed as source files, all other
input (the already compiled classes) are fed via the `-inpath` option.

With this setup, we can even compile-time weave Scala (and probably also
Kotlin) classes.

For some reasons, scala+ajc does not work for Mill <=0.9.

I think it's not worth to debug it. It's probably related to some
refactoring in 0.10 regarding the "override" detection and the out
directory layout of overridden targets. But mill-aspectj still work
for older Mill versions, so we still support these platforms.

Fix: #25 